### PR TITLE
PrivateKeyList cannot be constructed from array

### DIFF
--- a/lib/BlockCypher/Crypto/PrivateKeyList.php
+++ b/lib/BlockCypher/Crypto/PrivateKeyList.php
@@ -2,7 +2,7 @@
 
 namespace BlockCypher\Crypto;
 
-use BitWasp\Bitcoin\Key\PrivateKeyInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
 use BlockCypher\Validation\ArgumentArrayValidator;
 use BlockCypher\Validation\CoinSymbolValidator;
 


### PR DESCRIPTION
because the class name has changed, hinders signing transactions